### PR TITLE
Contributing Web3 Scam Sites

### DIFF
--- a/blacklist/domains.json
+++ b/blacklist/domains.json
@@ -97785,4 +97785,6 @@
   "goblimtown.com",
   "boki.gift",
   "adidas-metaverse.io"
-]
+  "dappradar.wtf"
+  "bridge.blockscape.org"
+}

--- a/blacklist/domains.json
+++ b/blacklist/domains.json
@@ -97787,4 +97787,4 @@
   "adidas-metaverse.io"
   "dappradar.wtf"
   "bridge.blockscape.org"
-}
+]


### PR DESCRIPTION
a bogus dapp radar from a medium article and a bogus clone of a production site. 