### PR TITLE
adding bogus bridge domain

### DIFF
--- a/blacklist/domains.json
+++ b/blacklist/domains.json
@@ -97787,4 +97787,5 @@
   "adidas-metaverse.io"
   "dappradar.wtf"
   "bridge.blockscape.org"
+  "optics-bridge.com"
 ]


### PR DESCRIPTION
scam site being promoted on discord, hosted by uncooperative name registrar